### PR TITLE
ci: add npm trusted publishers support via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   release:
     name: 🚀 release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
@@ -18,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
 
       - name: Debug npm registry
@@ -28,6 +31,4 @@ jobs:
         run: npm ci && npm run build
 
       - name: 🚀 publish
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Description
- Enable keyless npm publishing via OIDC (Trusted Publishers)
- Replaces the `NPM_AUTH_TOKEN` secret with GitHub's OIDC-based authentication. Adds `--provenance` to the publish command so future releases will include a signed provenance attestation on npmjs.com

## Related Issues
- https://algorandfoundation.atlassian.net/browse/PERA-3805
